### PR TITLE
Add icons and date device class for waste sensors

### DIFF
--- a/custom_components/him_waste_calendar/const.py
+++ b/custom_components/him_waste_calendar/const.py
@@ -14,6 +14,14 @@ CATEGORIES = [
     "glass_metall",
 ]
 
+CATEGORY_ICONS = {
+    "plast": "mdi:recycle",
+    "mat": "mdi:food-apple",
+    "papir": "mdi:file-document",
+    "rest": "mdi:trash-can",
+    "glass_metall": "mdi:bottle-wine",
+}
+
 MONTHS = {
     "januar": 1,
     "februar": 2,

--- a/custom_components/him_waste_calendar/sensor.py
+++ b/custom_components/him_waste_calendar/sensor.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CATEGORIES, DOMAIN
+from .const import CATEGORIES, DOMAIN, CATEGORY_ICONS
 from .coordinator import WasteCalendarCoordinator
 
 
@@ -29,11 +29,14 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
 class WasteCategorySensor(CoordinatorEntity[WasteCalendarCoordinator], SensorEntity):
     """Sensor representing the next date for a specific category."""
 
+    _attr_device_class = SensorDeviceClass.DATE
+
     def __init__(self, coordinator: WasteCalendarCoordinator, category: str) -> None:
         super().__init__(coordinator)
         self._category = category
         self._attr_name = f"HIM next {category.replace('_', ' ')}"
         self._attr_unique_id = f"{coordinator.property_id}_{category}"
+        self._attr_icon = CATEGORY_ICONS.get(category)
 
     @property
     def native_value(self) -> str | None:
@@ -43,10 +46,13 @@ class WasteCategorySensor(CoordinatorEntity[WasteCalendarCoordinator], SensorEnt
 class WasteNextSensor(CoordinatorEntity[WasteCalendarCoordinator], SensorEntity):
     """Sensor showing the next waste collection of any type."""
 
+    _attr_device_class = SensorDeviceClass.DATE
+
     def __init__(self, coordinator: WasteCalendarCoordinator) -> None:
         super().__init__(coordinator)
         self._attr_name = "HIM next collection"
         self._attr_unique_id = f"{coordinator.property_id}_next"
+        self._attr_icon = "mdi:calendar"
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- use dedicated icons for each waste category sensor
- show calendar icon for the upcoming collection sensor
- expose all waste sensors as date sensors via device class

## Testing
- `pytest`
- `pre-commit run --files custom_components/him_waste_calendar/sensor.py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ace18b00848326b69b39058ffdbc1e