### PR TITLE
Group sensors under device and expose last refresh time

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ Custom Home Assistant integration that scrapes HIM's waste calendar website and 
 ## Configuration
 
 Use the configuration flow and enter your property ID when prompted. The integration will create one sensor per waste category and an aggregate sensor showing the next upcoming collection.
+
+All sensors for a property are grouped under a single device in Home Assistant and expose a `last_refresh` attribute indicating when data was last updated.


### PR DESCRIPTION
## Summary
- group sensors from each property under a single device
- expose `last_refresh` attribute on sensors
- ensure sensors return native `date` objects instead of strings

## Testing
- `pre-commit run --files README.md custom_components/him_waste_calendar/sensor.py` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ace60ad3248326b30366db3e32bac1