### PR TITLE
Handle missing last_update_success_time attribute

### DIFF
--- a/custom_components/him_waste_calendar/sensor.py
+++ b/custom_components/him_waste_calendar/sensor.py
@@ -40,7 +40,7 @@ class WasteCalendarEntity(CoordinatorEntity[WasteCalendarCoordinator]):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return default attributes for all sensors."""
-        last = self.coordinator.last_update_success_time
+        last = getattr(self.coordinator, "last_update_success_time", None)
         return {"last_refresh": last.isoformat() if last else None}
 
 


### PR DESCRIPTION
## Summary
- avoid AttributeError when last_update_success_time is absent

## Testing
- `pytest -q`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aceb6821a4832685b5d486441d12e3