### PR TITLE
Track last refresh time

### DIFF
--- a/custom_components/him_waste_calendar/coordinator.py
+++ b/custom_components/him_waste_calendar/coordinator.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import timedelta, date
+from datetime import timedelta, date, datetime
 import logging
 
 import async_timeout
@@ -10,6 +10,7 @@ from bs4 import BeautifulSoup
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
 
 from .const import CATEGORIES, DOMAIN, MONTHS
 
@@ -23,6 +24,7 @@ class WasteCalendarCoordinator(DataUpdateCoordinator[dict[str, str]]):
         """Initialize the coordinator."""
         self.property_id = property_id
         self.url = f"https://him.as/tommekalender/?eiendomId={property_id}"
+        self.last_refresh: datetime | None = None
         super().__init__(
             hass,
             _LOGGER,
@@ -65,4 +67,5 @@ class WasteCalendarCoordinator(DataUpdateCoordinator[dict[str, str]]):
             try_date = date(year, month, day)
             data[name] = try_date.isoformat()
 
+        self.last_refresh = dt_util.utcnow()
         return data

--- a/custom_components/him_waste_calendar/sensor.py
+++ b/custom_components/him_waste_calendar/sensor.py
@@ -40,7 +40,7 @@ class WasteCalendarEntity(CoordinatorEntity[WasteCalendarCoordinator]):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return default attributes for all sensors."""
-        last = getattr(self.coordinator, "last_update_success_time", None)
+        last = getattr(self.coordinator, "last_refresh", None)
         return {"last_refresh": last.isoformat() if last else None}
 
 


### PR DESCRIPTION
## Summary
- Track last refresh time in coordinator using Home Assistant's dt util
- Expose last refresh timestamp via sensor attributes

## Testing
- `python -m py_compile custom_components/him_waste_calendar/coordinator.py custom_components/him_waste_calendar/sensor.py`
- `pytest -q`
- `ruff check`
- `flake8` *(fails: E302 expected 2 blank lines, found 1; E501 line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68acefb51de08326afe5ab7758609bc1