### PR TITLE
Add calendar support and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Custom Home Assistant integration that scrapes HIM's waste calendar website and 
 
 ## Configuration
 
-Use the configuration flow and enter your property ID when prompted. The integration will create one sensor per waste category and an aggregate sensor showing the next upcoming collection.
+Use the configuration flow and enter your property ID when prompted. The easiest way to find your property ID is to visit [him.no](https://him.no), search for your address and copy the `eiendomId` value from the browser's address bar. The integration will create one sensor per waste category and an aggregate sensor showing the next upcoming collection.
 
 All sensors for a property are grouped under a single device in Home Assistant and expose a `last_refresh` attribute indicating when data was last updated.

--- a/custom_components/him_waste_calendar/calendar.py
+++ b/custom_components/him_waste_calendar/calendar.py
@@ -1,0 +1,66 @@
+"""Calendar platform for the HIM Waste Calendar integration."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, time
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.util import dt as dt_util
+
+from .const import CATEGORY_ICONS, CATEGORY_NAMES, CATEGORIES, DOMAIN
+from .coordinator import WasteCalendarCoordinator
+from .entity import WasteCalendarEntity
+
+
+async def async_setup_entry(hass, entry, async_add_entities) -> None:
+    """Set up calendar entities from a config entry."""
+    coordinator: WasteCalendarCoordinator = hass.data[DOMAIN][entry.entry_id]
+    entities = [
+        WasteCalendar(coordinator, category)
+        for category in CATEGORIES
+    ]
+    async_add_entities(entities)
+
+
+class WasteCalendar(WasteCalendarEntity, CalendarEntity):
+    """Calendar entity representing next pickup date for a waste category."""
+
+    def __init__(self, coordinator: WasteCalendarCoordinator, category: str) -> None:
+        super().__init__(coordinator)
+        self._category = category
+        self._attr_name = CATEGORY_NAMES.get(
+            category, category.replace("_", " ").title()
+        )
+        self._attr_unique_id = f"{coordinator.property_id}_{category}_calendar"
+        self._attr_icon = CATEGORY_ICONS.get(category)
+
+    def _get_date(self) -> date | None:
+        raw = self.coordinator.data.get(self._category)
+        if isinstance(raw, date):
+            return raw
+        if isinstance(raw, str):
+            try:
+                return datetime.strptime(raw, "%Y-%m-%d").date()
+            except ValueError:
+                return None
+        return None
+
+    def _build_event(self) -> CalendarEvent | None:
+        d = self._get_date()
+        if not d:
+            return None
+        start = datetime.combine(d, time.min).replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+        end = start + timedelta(days=1)
+        return CalendarEvent(summary=self._attr_name, start=start, end=end)
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        return self._build_event()
+
+    async def async_get_events(
+        self, hass, start_date: datetime, end_date: datetime
+    ) -> list[CalendarEvent]:
+        ev = self._build_event()
+        if ev and ev.start < end_date and ev.end > start_date:
+            return [ev]
+        return []

--- a/custom_components/him_waste_calendar/const.py
+++ b/custom_components/him_waste_calendar/const.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 DOMAIN = "him_waste_calendar"
 CONF_PROPERTY_ID = "property_id"
-PLATFORMS: list[str] = ["sensor"]
+PLATFORMS: list[str] = ["sensor", "calendar"]
 
 CATEGORIES = [
     "plast",

--- a/custom_components/him_waste_calendar/entity.py
+++ b/custom_components/him_waste_calendar/entity.py
@@ -1,0 +1,26 @@
+"""Shared entity base for HIM Waste Calendar."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+
+class WasteCalendarEntity(CoordinatorEntity):
+    """Base entity class for HIM Waste Calendar."""
+
+    def __init__(self, coordinator) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.property_id)},
+            name="HIM Tømmekalender",
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | None]:
+        """Return default attributes for entities."""
+        last = getattr(self.coordinator, "last_refresh", None)
+        return {"last_refresh": last.isoformat() if last else None}

--- a/custom_components/him_waste_calendar/sensor.py
+++ b/custom_components/him_waste_calendar/sensor.py
@@ -6,11 +6,9 @@ from datetime import date, datetime
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
-from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
-
 from .const import CATEGORIES, DOMAIN, CATEGORY_ICONS, CATEGORY_NAMES
 from .coordinator import WasteCalendarCoordinator
+from .entity import WasteCalendarEntity
 
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
@@ -24,24 +22,6 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     entities.append(WasteNextSensor(coordinator))
 
     async_add_entities(entities)
-
-
-class WasteCalendarEntity(CoordinatorEntity[WasteCalendarCoordinator]):
-    """Base class for HIM Waste Calendar entities."""
-
-    def __init__(self, coordinator: WasteCalendarCoordinator) -> None:
-        """Initialize the base entity."""
-        super().__init__(coordinator)
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.property_id)},
-            name="HIM Tømmekalender",
-        )
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return default attributes for all sensors."""
-        last = getattr(self.coordinator, "last_refresh", None)
-        return {"last_refresh": last.isoformat() if last else None}
 
 
 class WasteCategorySensor(WasteCalendarEntity, SensorEntity):


### PR DESCRIPTION
## Summary
- Add instructions for retrieving property ID from him.no
- Expose garbage pickup dates as calendar events

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ad6a182f0883268e759312fd1d4588