### PR TITLE
Add combined waste collection calendar and rename categories

### DIFF
--- a/custom_components/him_waste_calendar/calendar.py
+++ b/custom_components/him_waste_calendar/calendar.py
@@ -15,8 +15,11 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     """Set up calendar entities from a config entry."""
     coordinator: WasteCalendarCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities = [
-        WasteCalendar(coordinator, category)
-        for category in CATEGORIES
+        WasteCollectionCalendar(coordinator),
+        *[
+            WasteCalendar(coordinator, category)
+            for category in CATEGORIES
+        ],
     ]
     async_add_entities(entities)
 
@@ -30,7 +33,7 @@ class WasteCalendar(WasteCalendarEntity, CalendarEntity):
         name = CATEGORY_NAMES.get(
             category, category.replace("_", " ").title()
         )
-        self._attr_name = f"{name} kalender"
+        self._attr_name = name
         self._attr_unique_id = f"{coordinator.property_id}_{category}_calendar"
         self._attr_icon = CATEGORY_ICONS.get(category)
 
@@ -64,3 +67,79 @@ class WasteCalendar(WasteCalendarEntity, CalendarEntity):
         if ev and ev.start < end_date.date() and ev.end > start_date.date():
             return [ev]
         return []
+
+
+class WasteCollectionCalendar(WasteCalendarEntity, CalendarEntity):
+    """Calendar entity representing all waste collection days."""
+
+    def __init__(self, coordinator: WasteCalendarCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_name = "Avfallstømming"
+        self._attr_unique_id = f"{coordinator.property_id}_collection_calendar"
+        self._attr_icon = "mdi:trash-can-clock"
+
+    def _events_by_date(self) -> dict[date, list[str]]:
+        events: dict[date, list[str]] = {}
+        for category, raw in self.coordinator.data.items():
+            d: date | None = None
+            if isinstance(raw, date):
+                d = raw
+            elif isinstance(raw, str):
+                try:
+                    d = datetime.strptime(raw, "%Y-%m-%d").date()
+                except ValueError:
+                    d = None
+            if d is None:
+                continue
+            events.setdefault(d, []).append(category)
+        return events
+
+    def _next_event(self) -> tuple[date, list[str]] | None:
+        events = self._events_by_date()
+        if not events:
+            return None
+        d = min(events)
+        return d, events[d]
+
+    def _build_event(self, d: date, cats: list[str]) -> CalendarEvent:
+        start = d
+        end = d + timedelta(days=1)
+        desc = ", ".join(
+            CATEGORY_NAMES.get(c, c.replace("_", " ").title()) for c in cats
+        )
+        return CalendarEvent(
+            summary=self._attr_name,
+            start=start,
+            end=end,
+            description=desc,
+        )
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        nxt = self._next_event()
+        if not nxt:
+            return None
+        d, cats = nxt
+        return self._build_event(d, cats)
+
+    async def async_get_events(
+        self, hass, start_date: datetime, end_date: datetime
+    ) -> list[CalendarEvent]:
+        events = []
+        for d, cats in self._events_by_date().items():
+            if d < end_date.date() and d >= start_date.date():
+                events.append(self._build_event(d, cats))
+        return events
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | None]:
+        attrs = super().extra_state_attributes
+        nxt = self._next_event()
+        if nxt:
+            _d, cats = nxt
+            attrs["categories"] = [
+                CATEGORY_NAMES.get(c, c.replace("_", " ").title()) for c in cats
+            ]
+        else:
+            attrs["categories"] = []
+        return attrs

--- a/custom_components/him_waste_calendar/const.py
+++ b/custom_components/him_waste_calendar/const.py
@@ -23,11 +23,11 @@ CATEGORY_ICONS = {
 }
 
 CATEGORY_NAMES = {
-    "plast": "Plast",
-    "mat": "Mat",
-    "papir": "Papir",
-    "rest": "Rest",
-    "glass_metall": "Glass og metall",
+    "plast": "Plastavfall",
+    "mat": "Matavfall",
+    "papir": "Papiravfall",
+    "rest": "Restavfall",
+    "glass_metall": "Glass og metallavfall",
 }
 
 MONTHS = {


### PR DESCRIPTION
## Summary
- rename waste category names to include `avfall`
- add an `Avfallstømming` calendar that shows all collection dates with categories

## Testing
- `python -m py_compile custom_components/him_waste_calendar/const.py custom_components/him_waste_calendar/calendar.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae1f810e8883268785600d419a20dd