### PR TITLE
Combine waste categories into a single calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HIM Waste Calendar
 
-Custom Home Assistant integration that scrapes HIM's waste calendar website and exposes pickup dates as sensors.
+Custom Home Assistant integration that scrapes HIM's waste calendar website and exposes pickup dates as sensors and a unified calendar.
 
 ## Installation
 
@@ -10,6 +10,6 @@ Custom Home Assistant integration that scrapes HIM's waste calendar website and 
 
 ## Configuration
 
-Use the configuration flow and enter your property ID when prompted. The easiest way to find your property ID is to visit [him.no](https://him.no), search for your address and copy the `eiendomId` value from the browser's address bar. The integration will create one sensor per waste category and an aggregate sensor showing the next upcoming collection.
+Use the configuration flow and enter your property ID when prompted. The easiest way to find your property ID is to visit [him.no](https://him.no), search for your address and copy the `eiendomId` value from the browser's address bar. The integration will create one sensor per waste category, an aggregate sensor showing the next upcoming collection, and a single calendar entity collecting all categories.
 
 All sensors for a property are grouped under a single device in Home Assistant and expose a `last_refresh` attribute indicating when data was last updated.

--- a/custom_components/him_waste_calendar/calendar.py
+++ b/custom_components/him_waste_calendar/calendar.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, timedelta
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 
-from .const import CATEGORY_ICONS, CATEGORY_NAMES, CATEGORIES, DOMAIN
+from .const import CATEGORY_NAMES, DOMAIN
 from .coordinator import WasteCalendarCoordinator
 from .entity import WasteCalendarEntity
 
@@ -14,59 +14,7 @@ from .entity import WasteCalendarEntity
 async def async_setup_entry(hass, entry, async_add_entities) -> None:
     """Set up calendar entities from a config entry."""
     coordinator: WasteCalendarCoordinator = hass.data[DOMAIN][entry.entry_id]
-    entities = [
-        WasteCollectionCalendar(coordinator),
-        *[
-            WasteCalendar(coordinator, category)
-            for category in CATEGORIES
-        ],
-    ]
-    async_add_entities(entities)
-
-
-class WasteCalendar(WasteCalendarEntity, CalendarEntity):
-    """Calendar entity representing next pickup date for a waste category."""
-
-    def __init__(self, coordinator: WasteCalendarCoordinator, category: str) -> None:
-        super().__init__(coordinator)
-        self._category = category
-        name = CATEGORY_NAMES.get(
-            category, category.replace("_", " ").title()
-        )
-        self._attr_name = name
-        self._attr_unique_id = f"{coordinator.property_id}_{category}_calendar"
-        self._attr_icon = CATEGORY_ICONS.get(category)
-
-    def _get_date(self) -> date | None:
-        raw = self.coordinator.data.get(self._category)
-        if isinstance(raw, date):
-            return raw
-        if isinstance(raw, str):
-            try:
-                return datetime.strptime(raw, "%Y-%m-%d").date()
-            except ValueError:
-                return None
-        return None
-
-    def _build_event(self) -> CalendarEvent | None:
-        d = self._get_date()
-        if not d:
-            return None
-        start = d
-        end = d + timedelta(days=1)
-        return CalendarEvent(summary=self._attr_name, start=start, end=end)
-
-    @property
-    def event(self) -> CalendarEvent | None:
-        return self._build_event()
-
-    async def async_get_events(
-        self, hass, start_date: datetime, end_date: datetime
-    ) -> list[CalendarEvent]:
-        ev = self._build_event()
-        if ev and ev.start < end_date.date() and ev.end > start_date.date():
-            return [ev]
-        return []
+    async_add_entities([WasteCollectionCalendar(coordinator)])
 
 
 class WasteCollectionCalendar(WasteCalendarEntity, CalendarEntity):


### PR DESCRIPTION
## Summary
- consolidate calendar platform to expose a single `Avfallstømming` entity for all waste categories
- mention unified calendar in documentation

## Testing
- `pre-commit run --files custom_components/him_waste_calendar/calendar.py README.md` *(command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b30bacb4488326a97fd76a6b0c2fd8