### PR TITLE
Use recycle icon for waste calendar

### DIFF
--- a/custom_components/him_waste_calendar/calendar.py
+++ b/custom_components/him_waste_calendar/calendar.py
@@ -42,7 +42,7 @@ class WasteCollectionCalendar(WasteCalendarEntity, CalendarEntity):
         super().__init__(coordinator)
         self._attr_name = "Avfallstømming"
         self._attr_unique_id = f"{coordinator.property_id}_collection_calendar"
-        self._attr_icon = "mdi:trash-can-clock"
+        self._attr_icon = "mdi:recycle"
 
     def _events_by_date(self) -> dict[date, list[str]]:
         events: dict[date, list[str]] = {}


### PR DESCRIPTION
## Summary
- Replace calendar entity icon with mdi:recycle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e60edd648326ae6810b52806317b