### PR TITLE
Fix category order for waste types

### DIFF
--- a/custom_components/him_waste_calendar/const.py
+++ b/custom_components/him_waste_calendar/const.py
@@ -7,10 +7,10 @@ CONF_PROPERTY_ID = "property_id"
 PLATFORMS: list[str] = ["sensor", "calendar"]
 
 CATEGORIES = [
-    "plast",
+    "rest",
     "mat",
     "papir",
-    "rest",
+    "plast",
     "glass_metall",
 ]
 


### PR DESCRIPTION
## Summary
- align the waste category ordering with the source so restavfall and plastavfall get the correct dates

## Testing
- python -m compileall custom_components/him_waste_calendar

------
https://chatgpt.com/codex/tasks/task_e_68cc45881e708326870c856eb32097f9